### PR TITLE
CASMPET-5129: Change the metallb address pool to customer-management

### DIFF
--- a/kubernetes/cray-keycloak-gatekeeper/Chart.yaml
+++ b/kubernetes/cray-keycloak-gatekeeper/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "9.0.0"
 description: A Helm chart for Kubernetes
 name: cray-keycloak-gatekeeper
-version: 0.4.1
+version: 1.0.0

--- a/kubernetes/cray-keycloak-gatekeeper/templates/service.yaml
+++ b/kubernetes/cray-keycloak-gatekeeper/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
 {{ include "cray-keycloak-gatekeeper.labels" . | indent 4 }}
   annotations:
-    metallb.universe.tf/address-pool: customer-access
+    metallb.universe.tf/address-pool: {{ .Values.metalLbAddressPool }}
     external-dns.alpha.kubernetes.io/hostname: {{ range $idx, $val := .Values.hosts }}{{ if gt $idx 0 }},{{ end }}{{ $val }}{{ end }}
 spec:
   type: LoadBalancer

--- a/kubernetes/cray-keycloak-gatekeeper/values.yaml
+++ b/kubernetes/cray-keycloak-gatekeeper/values.yaml
@@ -21,6 +21,9 @@ keycloakClientSecret: keycloak-gatekeeper-client
 # authorization). This is expected to be the Istio ingress gateway.
 upstreamUrl: "https://istio-ingressgateway.istio-system.svc.cluster.local/"
 
+# The address pool that will be used.
+metalLbAddressPool: customer-management
+
 # The hostnames that keycloak-gatekeeper will proxy. Hosts must be 
 # overridden with valid values, a single value here is used to ensure
 # the chart builds successfully (e.g., the certificate chart requires


### PR DESCRIPTION
### Summary and Scope

The gatekeeper metallb address pool needs to be changed. I think
it's because of the bifurcated CAN work. This is the value that I
was told is correct now.

This change is not backwards compatible so the MAJOR version
number is bumped.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? Not sure.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-5129

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) No
Was a fresh Install tested? Y/N   If not, Why? N, upgrade/downgrade should be adequate for this change.
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER)  Manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

I deployed the chart and saw that the annotation on the Service changed as expected. Downgrading the chart caused the annotation to be changed back.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires: None
